### PR TITLE
Separate tests environment into .wp-env.test.json

### DIFF
--- a/.wp-env.test.json
+++ b/.wp-env.test.json
@@ -1,9 +1,14 @@
 {
 	"testsEnvironment": false,
+	"port": 8889,
 	"plugins": [
 		".",
 		"https://downloads.wordpress.org/plugin/wordpress-beta-tester.zip",
 		"https://downloads.wordpress.org/plugin/wp-downgrade.zip"
 	],
-	"phpmyadminPort": 9000
+	"phpmyadminPort": 9001,
+	"config": {
+		"WP_DEBUG": true,
+		"SCRIPT_DEBUG": true
+	}
 }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
 	},
 	"scripts": {
 		"wp-env": "wp-env",
+		"wp-env-test": "wp-env --config .wp-env.test.json",
 		"stop": "wp-env stop",
 		"start": "wp-scripts start",
 		"build": "wp-scripts build",


### PR DESCRIPTION
wp-env deprecated the "env", "testsPort", and "testsEnvironment" options and the implicit start of a tests environment alongside development. Set "testsEnvironment": false in .wp-env.json to silence the deprecation warning, flatten the development config, and move the tests environment to a dedicated .wp-env.test.json launched via the new wp-env-test script.